### PR TITLE
다크모드에서 QR코드가 정상적으로 표시되지 않는 문제 해결

### DIFF
--- a/docs/components/CreateQrCode/CreateQrCode.tsx
+++ b/docs/components/CreateQrCode/CreateQrCode.tsx
@@ -2,7 +2,7 @@ import { getPublicKey } from "@site/src/api";
 import React, { useEffect, useMemo, useState } from "react";
 import { JSEncrypt } from "jsencrypt";
 import { Box, Button, Card, Modal, TextField } from "@material-ui/core";
-import { QRCodeSVG } from "qrcode.react";
+import { QRCodeCanvas } from "qrcode.react";
 
 export function CreateQrCode(): JSX.Element {
   const [ltuid, setLtuid] = useState<string>("");
@@ -79,7 +79,7 @@ export function CreateQrCode(): JSX.Element {
         aria-describedby="modal-modal-description"
       >
         <Box sx={style}>
-          <QRCodeSVG value={data} size={200} />
+          <QRCodeCanvas value={data} size={300} includeMargin={true} />
         </Box>
       </Modal>
     </Card>


### PR DESCRIPTION
## 관련 이슈

#18 

## 현상

윈도우의 다크모드 브라우저에서 QR코드가 정상적으로 표시되지 않음

## 해결

SVG로 표시하던 QR코드를 캔버스로 변경

## 스크린샷

<img width="648" alt="2022-07-21_23-19-38" src="https://user-images.githubusercontent.com/30566564/180237318-ebaf63dd-f995-4b6c-9173-5f8065ff2c91.png">

